### PR TITLE
 Re-export pancurses::Input 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@
 
 extern crate pancurses;
 
+pub use pancurses::Input;
+
 use std::panic::*;
 
 /// The three options you can pass to `EasyCurses::set_cursor_visibility`. Note


### PR DESCRIPTION
As to not require the user to also be dependent on pancurses; but only easycurses.