### PR TITLE
Revert un_get_input to take a normal reference

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -705,8 +705,8 @@ impl EasyCurses {
   /// Pushes an `Input` value into the input stack so that it will be returned
   /// by the next call to `get_input`. The return value is if the operation
   /// was successful.
-  pub fn un_get_input<I: AsRef<pancurses::Input>>(&mut self, input: I) -> bool {
-    to_bool(self.win.ungetch(input.as_ref()))
+  pub fn un_get_input(&mut self, input: &pancurses::Input) -> bool {
+    to_bool(self.win.ungetch(input))
   }
 
   /// Sets the window to use the number of lines and columns specified. If you


### PR DESCRIPTION
pancurses::Input doesn't implement AsRef<pancurses::Input> so un_get_input can't be called directly with this type

This reverts ef818d